### PR TITLE
Distinct entities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:5.0.0-alpha2"
+    classpath "org.elasticsearch.gradle:build-tools:5.0.0-alpha3"
   }
 }
 
@@ -32,10 +32,10 @@ esplugin {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-  compile 'org.elasticsearch:elasticsearch:5.0.0-alpha2'
+  compile 'org.elasticsearch:elasticsearch:5.0.0-alpha3'
   compile 'org.apache.opennlp:opennlp-tools:1.6.0'
 
-  testCompile 'org.elasticsearch.test:framework:5.0.0-alpha2'
+  testCompile 'org.elasticsearch.test:framework:5.0.0-alpha3'
 }
 
 bundlePlugin {

--- a/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/EntityFinderService.java
+++ b/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/EntityFinderService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright [2016] [Alexander Reelsen]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package de.spinscale.elasticsearch.ingest.opennlp;
+
+import java.util.List;
+
+public interface EntityFinderService {
+    public List<String> findNames(String content);
+    public List<String> findDates(String content);
+    public List<String> findLocations(String content);
+}

--- a/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpProcessor.java
+++ b/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpProcessor.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 
 import static org.elasticsearch.ingest.core.ConfigurationUtils.newConfigurationException;
 import static org.elasticsearch.ingest.core.ConfigurationUtils.readOptionalList;
@@ -40,12 +41,12 @@ public class OpenNlpProcessor extends AbstractProcessor {
 
     public static final String TYPE = "opennlp";
 
-    private final OpenNlpService openNlpService;
+    private final EntityFinderService openNlpService;
     private final String field;
     private final String targetField;
     private final Set<Property> properties;
 
-    OpenNlpProcessor(OpenNlpService openNlpService, String tag, String field, String targetField, Set<Property> properties) throws
+    OpenNlpProcessor(EntityFinderService openNlpService, String tag, String field, String targetField, Set<Property> properties) throws
             IOException {
         super(tag);
         this.openNlpService = openNlpService;
@@ -146,16 +147,13 @@ public class OpenNlpProcessor extends AbstractProcessor {
     }
 
     private static void merge(Map<String,List<String>> map, String key, List<String> values) {
-        if (values.size() > 0) {
-            if (!map.containsKey(key))
-              map.put(key, values);
-            else {
-              List<String> merged = new ArrayList<String>();
-              merged.addAll( map.get(key) );
-              merged.removeAll(values); // remove duplicates
-              merged.addAll(values);
-              map.put(key, merged);
-            }
-        }
+        if (values.size() == 0) return;
+
+        HashSet<String> distinctValues = new HashSet<String>(values);
+        if (map.containsKey(key))
+            distinctValues.addAll(map.get(key));
+
+        List<String> merged = new ArrayList<String>(distinctValues);
+        map.put(key, merged);
     }
 }

--- a/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpService.java
+++ b/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpService.java
@@ -36,7 +36,7 @@ import java.util.List;
 /**
  * OpenNLP name finders are not thread safe, so we load them via a thread local hack
  */
-public class OpenNlpService {
+public class OpenNlpService implements EntityFinderService {
 
     private final Path configDirectory;
     private final ESLogger logger;

--- a/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpProcessorTests.java
+++ b/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpProcessorTests.java
@@ -88,6 +88,35 @@ public class OpenNlpProcessorTests extends ESTestCase {
         assertThatHasElements(entityData, "locations", "Paris", "Munich", "New York");
     }
 
+    public void testThatExtractedEntitiesAreDistinct() throws Exception {
+
+        EntityFinderService mockService = new EntityFinderService() {
+            public List<String> findNames(String content) { 
+                return Arrays.asList("Kobe Bryant", "Kobe Bryant", "Michael Jordan", "Michael Jordan"); 
+            }
+            public List<String> findDates(String content) { 
+                return Arrays.asList("Yesterday", "Yesterday"); 
+            }
+            public List<String> findLocations(String content) { 
+                return Arrays.asList("Munich", "Munich", "New York", "New York"); 
+            }
+        };
+
+        OpenNlpProcessor processor = new OpenNlpProcessor(mockService, randomAsciiOfLength(10), "source_field", "target_field",
+                EnumSet.allOf(OpenNlpProcessor.Property.class));
+
+        Map<String, Object> entityData = getIngestDocumentData(processor);
+
+        List<String> values = getValues(entityData, "names");
+        assertEquals(Arrays.asList("Kobe Bryant", "Michael Jordan"), values);
+
+        values = getValues(entityData, "dates");
+        assertEquals(Arrays.asList("Yesterday"), values);
+
+        values = getValues(entityData, "locations");
+        assertEquals(Arrays.asList("Munich", "New York"), values);
+    }
+
     private Map<String, Object> getIngestDocumentData(OpenNlpProcessor processor) throws Exception {
         IngestDocument ingestDocument = getIngestDocument();
         processor.execute(ingestDocument);
@@ -95,11 +124,14 @@ public class OpenNlpProcessorTests extends ESTestCase {
     }
 
     private IngestDocument getIngestDocument() throws Exception {
-        Map<String, Object> document = new HashMap<>();
-        document.put("source_field", "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever " +
+        return getIngestDocument("Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever " +
                 "scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the " +
                 "hottest day of the year.");
+    }
 
+    private IngestDocument getIngestDocument(String content) throws Exception {
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", content);
         return RandomDocumentPicks.randomIngestDocument(random(), document);
     }
 
@@ -110,11 +142,15 @@ public class OpenNlpProcessorTests extends ESTestCase {
     }
 
     private void assertThatHasElements(Map<String, Object> entityData, String field, String ... items) {
+        List<String> values = getValues(entityData, field);
+        assertThat(values, containsInAnyOrder(items));
+    }
+
+    private List<String> getValues(Map<String, Object> entityData, String field) {
         assertThat(entityData, hasKey(field));
         assertThat(entityData.get(field), instanceOf(List.class));
-
         @SuppressWarnings("unchecked")
-        List<String> names = (List<String>) entityData.get(field);
-        assertThat(names, containsInAnyOrder(items));
+        List<String> values = (List<String>) entityData.get(field);
+        return values;
     }
 }


### PR DESCRIPTION
Noticed that the openNLPFinderService may return duplicates, i.e. for dates "4748, 4748, ...". Resolved using a hashset. 

Also updated to alpha3. However, with alpha3 the "OpenNlpRestIT"-Test breaks for some reason. Since it contains no logic on its own, it suspect it's only there to satisfy build conventions
