### PR TITLE
Support for Part of Speech tags counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Elasticsearch OpenNLP Ingest Processor
+# Elasticsearch OpenNLP Ingest Processors
 
 I wrote a [opennlp mapping plugin](https://github.com/spinscale/elasticsearch-opennlp-plugin) a couple of years ago and people asked me, why I did not update it. The main reason was, that it was a bad architectural choice as mentioned in the [openlp plugin README](https://github.com/spinscale/elasticsearch-opennlp-plugin#elasticsearch-opennlp-plugin). With the introduction of ingest processors in Elasticsearch 5.0 this problem has been resolved.
 
-This processor is doing named/date/location/'whatever you have a model for' entity recognition and stores the output in the JSON before it is being stored.
+The OpenNLP ingest processors are:
+* Doing name/date/location/'whatever you have a model for' entity recognition
+* Counting the different parts of speech tags
+
+The processor also save the output in the JSON before it is being stored.
 
 This plugin is also intended to show you, that using gradle as a build system makes it very easy to reuse the testing facilities that elasticsearch already provides. First, you can run regular tests, but by adding a rest test, the plugin will be packaged and unzipped against elasticsearch, allowing you to execute a real end-to-end test, by just adding a java test class.
 
@@ -16,32 +20,34 @@ This plugin is also intended to show you, that using gradle as a build system ma
 
 ## Usage
 
-This is how you configure a pipeline with support for opennlp
+The opennlp plugin provides two processors, opennlp_ner for doing named entity recognition and opennlp_pos for counting the part of speech tags.
 
-You can add the following lines to the `config/elasticsearch.yml` (as those models are shipped by default, they are easy to enable). The models are looked up in the `config/ingest-opennlp/` directory.
+### opennlp_ner
+
+This is how you configure a pipeline with support for opennlp_ner. You can add the following lines to the `config/elasticsearch.yml` (as those models are shipped by default, they are easy to enable). The models are looked up in the `config/ingest-opennlp/` directory.
 
 ```
-ingest.opennlp.model.file.persons: en-ner-persons.bin
-ingest.opennlp.model.file.dates: en-ner-dates.bin
-ingest.opennlp.model.file.locations: en-ner-locations.bin
+ingest.opennlp.model.file.ner.names: en-ner-persons.bin
+ingest.opennlp.model.file.ner.dates: en-ner-dates.bin
+ingest.opennlp.model.file.ner.locations: en-ner-locations.bin
 ```
 
 Now fire up Elasticsearch and configure a pipeline
 
 ```
-PUT _ingest/pipeline/opennlp-pipeline
+PUT _ingest/pipeline/opennlp-ner-pipeline
 {
   "description": "A pipeline to do named entity extraction",
   "processors": [
     {
-      "opennlp" : {
+      "opennlp_ner" : {
         "field" : "my_field"
       }
     }
   ]
 }
 
-PUT /my-index/my-type/1?pipeline=opennlp-pipeline
+PUT /my-index/my-type/1?pipeline=opennlp-ner-pipeline
 {
   "my_field" : "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year."
 }
@@ -61,12 +67,12 @@ You can also specify only certain named entities in the processor, i.e. if you o
 
 
 ```
-PUT _ingest/pipeline/opennlp-pipeline
+PUT _ingest/pipeline/opennlp-ner-pipeline
 {
   "description": "A pipeline to do named entity extraction",
   "processors": [
     {
-      "opennlp" : {
+      "opennlp_ner" : {
         "field" : "my_field"
         "fields" : [ "names" ]
       }
@@ -75,16 +81,130 @@ PUT _ingest/pipeline/opennlp-pipeline
 }
 ```
 
+### opennlp_pos
+
+You can add the following lines to the `config/elasticsearch.yml` (as those models are shipped by default, they are easy to enable). The models are looked up in the `config/ingest-opennlp/` directory.
+
+```
+ingest.opennlp.model.file.pos: en-pos-maxent.bin
+```
+
+Configure a pipeline
+
+```
+PUT _ingest/pipeline/opennlp-pos-pipeline
+{
+  "description": "A pipeline to count part of speech tags",
+  "processors": [
+    {
+      "opennlp_pos" : {
+        "field" : "my_field"
+      }
+    }
+  ]
+}
+
+PUT /my-index/my-type/1?pipeline=opennlp-pos-pipeline
+{
+  "my_field" : "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year."
+}
+
+GET /my-index/my-type/1
+{
+  "my_field" : "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year.",
+  "tags": {
+    "CC": 1,
+    "CD": 3,
+    "DT": 5,
+    "IN": 4,
+    "JJ": 1,
+    "JJS": 2,
+    "NN": 6,
+    "NNP": 7,
+    "NNS": 3,
+    "PUNCT": 5,
+    "RB": 6,
+    "VBD": 1,
+    "VBN": 2,
+    "VBZ": 4
+  }
+}
+```
+
+You can specify only certain tags in the processor, i.e. if you only want to count proper nouns
+
+
+```
+PUT _ingest/pipeline/opennlp-pos-pipeline
+{
+  "description": "A pipeline to do named entity extraction",
+  "processors": [
+    {
+      "opennlp_pos" : {
+        "field" : "my_field",
+        "tags" : [ "NNP" ]
+      }
+    }
+  ]
+}
+```
+
+You can also count the proportion of each tags (as a number between 0 and 1)
+
+```
+PUT _ingest/pipeline/opennlp-pos-pipeline
+{
+  "description": "A pipeline to do named entity extraction",
+  "processors": [
+    {
+      "opennlp_pos" : {
+        "field" : "my_field",
+        "normalize" : true
+      }
+    }
+  ]
+}
+
+GET /my-index/my-type/1
+{
+  "my_field" : "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year.",
+  "tags": {
+    "CC": 0.02,
+    "CD": 0.06,
+    "DT": 0.1,
+    "IN": 0.08,
+    "JJ": 0.02,
+    "JJS": 0.04,
+    "NN": 0.12,
+    "NNP": 0.14,
+    "NNS": 0.06,
+    "PUNCT": 0.1,
+    "RB": 0.12,
+    "VBD": 0.02,
+    "VBN": 0.04,
+    "VBZ": 0.08
+  }
+}
+```
+
 ## Configuration
 
-You can configure own models per field, the setting for this is prefixed `ingest.opennlp.model.file.`. So you can configure any model with any field name, by specifying a name and a path to file, like the three examples below:
+### opennlp_ner
+
+You can configure own models per field, the setting for this is prefixed `ingest.opennlp.model.file.ner`. So you can configure any model with any field name, by specifying a name and a path to file, like the three examples below:
 
 | Parameter | Use |
 | --- | --- |
-| ingest.opennlp.model.file.name     | Configure the file for named entity recognition for the field name    |
-| ingest.opennlp.model.file.date     | Configure the file for date entity recognition for the field date     |
-| ingest.opennlp.model.file.person   | Configure the file for person entity recognition for the field date     |
-| ingest.opennlp.model.file.WHATEVER | Configure the file for WHATEVER entity recognition for the field date     |
+| ingest.opennlp.model.file.ner.name     | Configure the file for named entity recognition for the field name    |
+| ingest.opennlp.model.file.ner.date     | Configure the file for date entity recognition for the field date     |
+| ingest.opennlp.model.file.ner.person   | Configure the file for person entity recognition for the field date     |
+| ingest.opennlp.model.file.ner.WHATEVER | Configure the file for WHATEVER entity recognition for the field date     |
+
+### opennlp_pos
+
+| Parameter | Use |
+| --- | --- |
+| ingest.opennlp.model.file.pos | Configure the file for POS tagging |
 
 ## Setup
 
@@ -99,7 +219,7 @@ This will produce a zip file in `build/distributions`. As part of the build, the
 After building the zip file, you can install it like this
 
 ```bash
-bin/plugin install file:///path/to/elasticsearch-ingest-opennlp/build/distribution/ingest-opennlp-0.0.1-SNAPSHOT.zip
+bin/elasticsearch-plugin install file:///path/to/elasticsearch-ingest-opennlp/build/distribution/ingest-opennlp-5.6.1.1-SNAPSHOT.zip
 ```
 
 There is no need to configure anything, as the models art part of the zip file.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # Elasticsearch OpenNLP Ingest Processors
 
-I wrote a [opennlp mapping plugin](https://github.com/spinscale/elasticsearch-opennlp-plugin) a couple of years ago and people asked me, why I did not update it. The main reason was, that it was a bad architectural choice as mentioned in the [openlp plugin README](https://github.com/spinscale/elasticsearch-opennlp-plugin#elasticsearch-opennlp-plugin). With the introduction of ingest processors in Elasticsearch 5.0 this problem has been resolved.
+This is a fork from the [Elasticsearch OpenNLP Ingest Processor](https://github.com/spinscale/elasticsearch-ingest-opennlp) written by spinscale.
 
-The OpenNLP ingest processors are:
-* Doing name/date/location/'whatever you have a model for' entity recognition
-* Counting the different parts of speech tags
+In addition to the original processor doing name/date/location/'whatever you have a model for' entity recognition, it adds a new processor for counting the different part of speech tags in the ingested document. Both processors save the output in the JSON before it is being stored.
 
-The processor also save the output in the JSON before it is being stored.
-
-This plugin is also intended to show you, that using gradle as a build system makes it very easy to reuse the testing facilities that elasticsearch already provides. First, you can run regular tests, but by adding a rest test, the plugin will be packaged and unzipped against elasticsearch, allowing you to execute a real end-to-end test, by just adding a java test class.
-
+<!---
 ## Installation
 
 | ES    | Command |
@@ -17,10 +12,10 @@ This plugin is also intended to show you, that using gradle as a build system ma
 | 5.2.0 | `bin/elasticsearch-plugin install https://oss.sonatype.org/content/repositories/releases/de/spinscale/elasticsearch/plugin/ingest/ingest-opennlp/5.2.0.1/ingest-opennlp-5.2.0.1.zip` |
 | 5.1.2 | `bin/elasticsearch-plugin install https://oss.sonatype.org/content/repositories/releases/de/spinscale/elasticsearch/plugin/ingest/ingest-opennlp/5.1.2.1/ingest-opennlp-5.1.2.1.zip` |
 | 5.1.1 | `bin/elasticsearch-plugin install https://oss.sonatype.org/content/repositories/releases/de/spinscale/elasticsearch/plugin/ingest/ingest-opennlp/5.1.1.1/ingest-opennlp-5.1.1.1.zip` |
-
+-->
 ## Usage
 
-The opennlp plugin provides two processors, opennlp_ner for doing named entity recognition and opennlp_pos for counting the part of speech tags.
+The plugin provides two processors, opennlp_ner for doing named entity recognition and opennlp_pos for counting the part of speech tags.
 
 ### opennlp_ner
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,10 @@ bundlePlugin {
 }
 
 integTestCluster {
-  setting 'ingest.opennlp.model.file.names',     'en-ner-persons.bin'
-  setting 'ingest.opennlp.model.file.locations', 'en-ner-locations.bin'
-  setting 'ingest.opennlp.model.file.dates',     'en-ner-dates.bin'
+  setting 'ingest.opennlp.model.file.ner.names',     'en-ner-persons.bin'
+  setting 'ingest.opennlp.model.file.ner.locations', 'en-ner-locations.bin'
+  setting 'ingest.opennlp.model.file.ner.dates',     'en-ner-dates.bin'
+  setting 'ingest.opennlp.model.file.pos',           'en-pos-maxent.bin'
 }
 
 // check style can be disabled, or you can configure a different checkstyle file
@@ -80,6 +81,7 @@ task downloadModels {
     downloadIfNotExists('http://opennlp.sourceforge.net/models-1.5/en-ner-person.bin',   'en-ner-persons.bin')
     downloadIfNotExists('http://opennlp.sourceforge.net/models-1.5/en-ner-location.bin', 'en-ner-locations.bin')
     downloadIfNotExists('http://opennlp.sourceforge.net/models-1.5/en-ner-date.bin',     'en-ner-dates.bin')
+    downloadIfNotExists('http://opennlp.sourceforge.net/models-1.5/en-pos-maxent.bin',   'en-pos-maxent.bin')
   }
 }
 
@@ -112,11 +114,11 @@ uploadArchives {
       beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
       repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
       }
 
       snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
       }
 
       pom.project {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
  }
 
   dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:5.6.0"
+    classpath "org.elasticsearch.gradle:build-tools:5.6.1"
     classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
   }
 }
@@ -18,7 +18,7 @@ plugins {
 import de.undercouch.gradle.tasks.download.Download
 
 group = 'de.spinscale.elasticsearch.plugin.ingest'
-version = '5.6.0.1-SNAPSHOT'
+version = '5.6.1.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'elasticsearch.esplugin'
@@ -41,7 +41,7 @@ esplugin {
   // copyright notices, may be different than the above notice
   noticeFile rootProject.file('NOTICE.txt')
   name 'ingest-opennlp'
-  description 'Ingest processor that uses OpenNLP for named entity extraction'
+  description 'Ingest processor that uses OpenNLP for named entity extraction and part of speech tagging'
   classname 'de.spinscale.elasticsearch.ingest.opennlp.IngestOpenNlpPlugin'
 }
 
@@ -137,7 +137,7 @@ uploadArchives {
         name 'Elasticsearch Ingest OpenNLP Detection Plugin'
         packaging 'zip'
         artifactId 'ingest-opennlp'
-        description 'Ingest processor that uses OpenNLP for named entity extraction'
+        description 'Ingest processor that uses OpenNLP for named entity extraction and part of speech tagging'
         url 'https://github.com/spinscale/elasticsearch-ingest-opennlp'
 
         scm {

--- a/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/IngestOpenNlpPlugin.java
+++ b/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/IngestOpenNlpPlugin.java
@@ -26,6 +26,7 @@ import org.elasticsearch.plugins.Plugin;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +47,9 @@ public class IngestOpenNlpPlugin extends Plugin implements IngestPlugin {
         OpenNlpService openNlpService = new OpenNlpService(configDirectory, parameters.env.settings());
         openNlpService.start();
 
-        return Collections.singletonMap(OpenNlpProcessor.TYPE, new OpenNlpProcessor.Factory(openNlpService));
+        Map<String, Processor.Factory> processors = new HashMap<>();
+        processors.put(OpenNlpNerProcessor.TYPE, new OpenNlpNerProcessor.Factory(openNlpService));
+        processors.put(OpenNlpPosProcessor.TYPE, new OpenNlpPosProcessor.Factory(openNlpService));
+        return Collections.unmodifiableMap(processors);
     }
 }

--- a/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpNerProcessor.java
+++ b/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpNerProcessor.java
@@ -32,18 +32,18 @@ import java.util.Set;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalList;
 import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
 
-public class OpenNlpProcessor extends AbstractProcessor {
+public class OpenNlpNerProcessor extends AbstractProcessor {
 
-    public static final String TYPE = "opennlp";
+    public static final String TYPE = "opennlp_ner";
 
     private final OpenNlpService openNlpService;
     private final String sourceField;
     private final String targetField;
     private final Set<String> fields;
 
-    OpenNlpProcessor(OpenNlpService openNlpService, String tag, String sourceField, String targetField, Set<String> fields) throws
-            IOException {
-        super(tag);
+    OpenNlpNerProcessor(OpenNlpService openNlpService, String processorTag, String sourceField, String targetField,
+                        Set<String> fields) throws IOException {
+        super(processorTag);
         this.openNlpService = openNlpService;
         this.sourceField = sourceField;
         this.targetField = targetField;
@@ -81,13 +81,15 @@ public class OpenNlpProcessor extends AbstractProcessor {
         }
 
         @Override
-        public OpenNlpProcessor create(Map<String, Processor.Factory> registry, String processorTag, Map<String, Object> config)
+        public OpenNlpNerProcessor create(Map<String, Processor.Factory> registry, String processorTag, Map<String, Object> config)
                 throws Exception {
             String field = readStringProperty(TYPE, processorTag, config, "field");
             String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "entities");
             List<String> fields = readOptionalList(TYPE, processorTag, config, "fields");
-            final Set<String> foundFields = fields == null || fields.size() == 0 ? openNlpService.getModels() : new HashSet<>(fields);
-            return new OpenNlpProcessor(openNlpService, processorTag, field, targetField, foundFields);
+            @SuppressWarnings("unchecked")
+            final Set<String> foundFields = fields == null || fields.size() == 0 ?
+                    ((Map)openNlpService.getModels().get("ner")).keySet() : new HashSet<>(fields);
+            return new OpenNlpNerProcessor(openNlpService, processorTag, field, targetField, foundFields);
         }
     }
 

--- a/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpPosProcessor.java
+++ b/src/main/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpPosProcessor.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright [2016] [Alexander Reelsen]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package de.spinscale.elasticsearch.ingest.opennlp;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalList;
+import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
+import static org.elasticsearch.ingest.ConfigurationUtils.readBooleanProperty;
+
+public class OpenNlpPosProcessor extends AbstractProcessor {
+
+    public static final String TYPE = "opennlp_pos";
+
+    private final OpenNlpService openNlpService;
+    private final String sourceField;
+    private final String targetField;
+    private final Set<String> tagSet;
+    private final boolean normalize;
+
+    OpenNlpPosProcessor(OpenNlpService openNlpService, String processorTag, String sourceField, String targetField,
+                        Set<String> tagSet, boolean normalize) throws
+            IOException {
+        super(processorTag);
+        this.openNlpService = openNlpService;
+        this.sourceField = sourceField;
+        this.targetField = targetField;
+        this.tagSet = tagSet;
+        this.normalize = normalize;
+    }
+
+    @Override
+    public void execute(IngestDocument ingestDocument) throws Exception {
+        String content = ingestDocument.getFieldValue(sourceField, String.class);
+
+        if (Strings.hasLength(content)) {
+
+            Map<String, Object> map = new TreeMap<>();
+            mergeExisting(map, ingestDocument, targetField);
+
+            Map<String, Number> tags = openNlpService.countTags(content, tagSet, normalize);
+            for (Map.Entry<String, Number> entry : tags.entrySet()) {
+                merge(map, entry.getKey(), entry.getValue());
+            }
+
+            ingestDocument.setFieldValue(targetField, map);
+        }
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        private OpenNlpService openNlpService;
+
+        public Factory(OpenNlpService openNlpService) {
+            this.openNlpService = openNlpService;
+        }
+
+        @Override
+        public OpenNlpPosProcessor create(Map<String, Processor.Factory> registry, String processorTag, Map<String, Object> config)
+                throws Exception {
+            String field = readStringProperty(TYPE, processorTag, config, "field");
+            List<String> tags = readOptionalList(TYPE, processorTag, config, "tags");
+            boolean normalize = readBooleanProperty(TYPE, processorTag, config, "normalize", false);
+            final Set<String> tagSet = tags == null || tags.size() == 0 ? null : new HashSet<>(tags);
+            String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "tags");
+            return new OpenNlpPosProcessor(openNlpService, processorTag, field, targetField, tagSet, normalize);
+        }
+    }
+
+    private static void mergeExisting(Map<String, Object> map, IngestDocument ingestDocument, String targetField) {
+        if (ingestDocument.hasField(targetField)) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> existing = ingestDocument.getFieldValue(targetField, Map.class);
+            map.putAll(existing);
+        }
+    }
+
+    private static void merge(Map<String, Object> map, String key, Number value) {
+        // Overwrite
+        map.put(key, value);
+    }
+}

--- a/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpNerProcessorTests.java
+++ b/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpNerProcessorTests.java
@@ -37,23 +37,23 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
-public class OpenNlpProcessorTests extends ESTestCase {
+public class OpenNlpNerProcessorTests extends ESTestCase {
 
     private OpenNlpService service;
 
     @Before
     public void createOpenNlpService() throws IOException {
         Settings settings = Settings.builder()
-                .put("ingest.opennlp.model.file.names", "en-ner-persons.bin")
-                .put("ingest.opennlp.model.file.locations", "en-ner-locations.bin")
-                .put("ingest.opennlp.model.file.dates", "en-ner-dates.bin")
+                .put("ingest.opennlp.model.file.ner.names", "en-ner-persons.bin")
+                .put("ingest.opennlp.model.file.ner.locations", "en-ner-locations.bin")
+                .put("ingest.opennlp.model.file.ner.dates", "en-ner-dates.bin")
                 .build();
 
         service = new OpenNlpService(getDataPath("/models/en-ner-persons.bin").getParent(), settings).start();
     }
 
     public void testThatExtractionsWork() throws Exception {
-        OpenNlpProcessor processor = new OpenNlpProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+        OpenNlpNerProcessor processor = new OpenNlpNerProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
                 new HashSet<>(Arrays.asList("names", "dates", "locations")));
 
         Map<String, Object> entityData = getIngestDocumentData(processor);
@@ -64,7 +64,7 @@ public class OpenNlpProcessorTests extends ESTestCase {
     }
 
     public void testThatFieldsCanBeExcluded() throws Exception {
-        OpenNlpProcessor processor = new OpenNlpProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+        OpenNlpNerProcessor processor = new OpenNlpNerProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
                 new HashSet<>(Arrays.asList("dates")));
 
         Map<String, Object> entityData = getIngestDocumentData(processor);
@@ -75,7 +75,7 @@ public class OpenNlpProcessorTests extends ESTestCase {
     }
 
     public void testThatExistingValuesAreMergedWithoutDuplicates() throws Exception {
-        OpenNlpProcessor processor = new OpenNlpProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+        OpenNlpNerProcessor processor = new OpenNlpNerProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
                 new HashSet<>(Arrays.asList("names", "dates", "locations")));
 
         IngestDocument ingestDocument = getIngestDocument();
@@ -101,9 +101,9 @@ public class OpenNlpProcessorTests extends ESTestCase {
         config.put("field", "source_field");
         config.put("target_field", "target_field");
 
-        OpenNlpProcessor.Factory factory = new OpenNlpProcessor.Factory(service);
+        OpenNlpNerProcessor.Factory factory = new OpenNlpNerProcessor.Factory(service);
         Map<String, Processor.Factory> registry = Collections.emptyMap();
-        OpenNlpProcessor processor = factory.create(registry, randomAlphaOfLength(10), config);
+        OpenNlpNerProcessor processor = factory.create(registry, randomAlphaOfLength(10), config);
 
         Map<String, Object> entityData = getIngestDocumentData(processor);
 
@@ -113,7 +113,7 @@ public class OpenNlpProcessorTests extends ESTestCase {
 
     }
 
-    private Map<String, Object> getIngestDocumentData(OpenNlpProcessor processor) throws Exception {
+    private Map<String, Object> getIngestDocumentData(OpenNlpNerProcessor processor) throws Exception {
         IngestDocument ingestDocument = getIngestDocument();
         processor.execute(ingestDocument);
         return getIngestDocumentData(ingestDocument);

--- a/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpPosProcessorTests.java
+++ b/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpPosProcessorTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright [2016] [Alexander Reelsen]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package de.spinscale.elasticsearch.ingest.opennlp;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+public class OpenNlpPosProcessorTests extends ESTestCase {
+
+    private OpenNlpService service;
+
+    @Before
+    public void createOpenNlpService() throws IOException {
+        Settings settings = Settings.builder()
+                .put("ingest.opennlp.model.file.pos", "en-pos-maxent.bin")
+                .build();
+
+        service = new OpenNlpService(getDataPath("/models/en-pos-maxent.bin").getParent(), settings).start();
+    }
+
+    public void testThatTaggingWork() throws Exception {
+        OpenNlpPosProcessor processor = new OpenNlpPosProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+                null, false);
+
+        Map<String, Object> entityData = getIngestDocumentData(processor);
+
+        assertThatHasValue(entityData, "CC", Integer.class, 1);
+        assertThatHasValue(entityData, "CD", Integer.class, 3);
+        assertThatHasValue(entityData, "DT", Integer.class, 5);
+        assertThatHasValue(entityData, "IN", Integer.class, 4);
+        assertThatHasValue(entityData, "JJ", Integer.class, 1);
+        assertThatHasValue(entityData, "JJS", Integer.class, 2);
+        assertThatHasValue(entityData, "NN", Integer.class, 6);
+        assertThatHasValue(entityData, "NNP", Integer.class, 7);
+        assertThatHasValue(entityData, "NNS", Integer.class, 3);
+        assertThatHasValue(entityData, "PUNCT", Integer.class, 5);
+        assertThatHasValue(entityData, "RB", Integer.class, 6);
+        assertThatHasValue(entityData, "VBD", Integer.class, 1);
+        assertThatHasValue(entityData, "VBN", Integer.class, 2);
+        assertThatHasValue(entityData, "VBZ", Integer.class, 4);
+    }
+
+    public void testThatTagsCanBeExcluded() throws Exception {
+        OpenNlpPosProcessor processor = new OpenNlpPosProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+                new HashSet<>(Arrays.asList("NN", "VBZ")), false);
+
+        Map<String, Object> entityData = getIngestDocumentData(processor);
+
+        assertThat(entityData, not(hasKey("CC")));
+        assertThat(entityData, not(hasKey("CD")));
+        assertThat(entityData, not(hasKey("DT")));
+        assertThat(entityData, not(hasKey("IN")));
+        assertThat(entityData, not(hasKey("JJ")));
+        assertThat(entityData, not(hasKey("JJS")));
+        assertThat(entityData, not(hasKey("NNP")));
+        assertThat(entityData, not(hasKey("NNS")));
+        assertThat(entityData, not(hasKey("PUNCT")));
+        assertThat(entityData, not(hasKey("RB")));
+        assertThat(entityData, not(hasKey("VBD")));
+        assertThat(entityData, not(hasKey("VBN")));
+        assertThatHasValue(entityData, "NN", Integer.class, 6);
+        assertThatHasValue(entityData, "VBZ", Integer.class, 4);
+    }
+
+    public void testThatNormalizeWorks() throws Exception {
+        OpenNlpPosProcessor processor = new OpenNlpPosProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+                null, true);
+
+        Map<String, Object> entityData = getIngestDocumentData(processor);
+
+        assertThatHasValue(entityData, "CD", Double.class, 0.06);
+        assertThatHasValue(entityData, "DT", Double.class, 0.1);
+        assertThatHasValue(entityData, "IN", Double.class,  0.08);
+        assertThatHasValue(entityData, "JJ", Double.class, 0.02);
+        assertThatHasValue(entityData, "JJS", Double.class, 0.04);
+        assertThatHasValue(entityData, "NN", Double.class, 0.12);
+        assertThatHasValue(entityData, "NNP", Double.class, 0.14);
+        assertThatHasValue(entityData, "NNS", Double.class, 0.06);
+        assertThatHasValue(entityData, "PUNCT", Double.class, 0.1);
+        assertThatHasValue(entityData, "RB", Double.class, 0.12);
+        assertThatHasValue(entityData, "VBD", Double.class, 0.02);
+        assertThatHasValue(entityData, "VBN", Double.class, 0.04);
+        assertThatHasValue(entityData, "VBZ", Double.class, 0.08);
+    }
+
+    public void testThatExistingValuesAreOverwritten() throws Exception {
+        OpenNlpPosProcessor processor = new OpenNlpPosProcessor(service, randomAlphaOfLength(10), "source_field", "target_field",
+                new HashSet<>(Arrays.asList("NN", "VBZ")), false);
+
+        IngestDocument ingestDocument = getIngestDocument();
+
+        Map<String, Object> entityData = new HashMap<>();
+        entityData.put("NN", 101);
+        entityData.put("VBD", 99.9);
+        entityData.put("VBZ", 102);
+
+        ingestDocument.setFieldValue("target_field", entityData);
+
+        processor.execute(ingestDocument);
+
+        entityData = getIngestDocumentData(ingestDocument);
+
+        assertThatHasValue(entityData, "NN", Integer.class, 6);
+        assertThatHasValue(entityData, "VBZ", Integer.class, 4);
+        assertThatHasValue(entityData, "VBD", Double.class, 99.9);
+    }
+
+    public void testConstructorNoTagsSpecified() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "source_field");
+        config.put("target_field", "target_field");
+
+        OpenNlpPosProcessor.Factory factory = new OpenNlpPosProcessor.Factory(service);
+        Map<String, Processor.Factory> registry = Collections.emptyMap();
+        OpenNlpPosProcessor processor = factory.create(registry, randomAlphaOfLength(10), config);
+
+        Map<String, Object> entityData = getIngestDocumentData(processor);
+
+        assertThat(entityData, hasKey("CC"));
+        assertThat(entityData, hasKey("CD"));
+        assertThat(entityData, hasKey("DT"));
+        assertThat(entityData, hasKey("IN"));
+        assertThat(entityData, hasKey("JJ"));
+        assertThat(entityData, hasKey("JJS"));
+        assertThat(entityData, hasKey("NNP"));
+        assertThat(entityData, hasKey("NNS"));
+        assertThat(entityData, hasKey("PUNCT"));
+        assertThat(entityData, hasKey("RB"));
+        assertThat(entityData, hasKey("VBD"));
+        assertThat(entityData, hasKey("VBN"));
+        assertThat(entityData, hasKey("NN"));
+        assertThat(entityData, hasKey("VBZ"));
+    }
+
+    public void testConstructorTagsSpecified() throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "source_field");
+        config.put("target_field", "target_field");
+        config.put("tags", Arrays.asList("NN", "VBZ"));
+
+        OpenNlpPosProcessor.Factory factory = new OpenNlpPosProcessor.Factory(service);
+        Map<String, Processor.Factory> registry = Collections.emptyMap();
+        OpenNlpPosProcessor processor = factory.create(registry, randomAlphaOfLength(10), config);
+
+        Map<String, Object> entityData = getIngestDocumentData(processor);
+
+        assertThat(entityData, not(hasKey("CC")));
+        assertThat(entityData, not(hasKey("CD")));
+        assertThat(entityData, not(hasKey("DT")));
+        assertThat(entityData, not(hasKey("IN")));
+        assertThat(entityData, not(hasKey("JJ")));
+        assertThat(entityData, not(hasKey("JJS")));
+        assertThat(entityData, not(hasKey("NNP")));
+        assertThat(entityData, not(hasKey("NNS")));
+        assertThat(entityData, not(hasKey("PUNCT")));
+        assertThat(entityData, not(hasKey("RB")));
+        assertThat(entityData, not(hasKey("VBD")));
+        assertThat(entityData, not(hasKey("VBN")));
+        assertThat(entityData, hasKey("NN"));
+        assertThat(entityData, hasKey("VBZ"));
+    }
+
+    private Map<String, Object> getIngestDocumentData(OpenNlpPosProcessor processor) throws Exception {
+        IngestDocument ingestDocument = getIngestDocument();
+        processor.execute(ingestDocument);
+        return getIngestDocumentData(ingestDocument);
+    }
+
+    private IngestDocument getIngestDocument() throws Exception {
+        return getIngestDocument("Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever " +
+                "scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the " +
+                "hottest day of the year.");
+    }
+
+    private IngestDocument getIngestDocument(String content) throws Exception {
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", content);
+        return RandomDocumentPicks.randomIngestDocument(random(), document);
+    }
+
+    private Map<String, Object> getIngestDocumentData(IngestDocument ingestDocument) throws Exception {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
+        return data;
+    }
+
+    private <T extends java.lang.Comparable<T>> void assertThatHasValue(Map<String, Object> entityData, String field,
+                                                                        Class<T> clazz, T value) {
+        assertThat(entityData, hasKey(field));
+        assertThat(entityData.get(field), instanceOf(clazz));
+        @SuppressWarnings("unchecked")
+        T v = (T) entityData.get(field);
+        assertThat(v, comparesEqualTo(value));
+    }
+}

--- a/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpServiceTests.java
+++ b/src/test/java/de/spinscale/elasticsearch/ingest/opennlp/OpenNlpServiceTests.java
@@ -22,10 +22,13 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 
 /*
@@ -36,9 +39,10 @@ public class OpenNlpServiceTests extends ESTestCase {
 
     public void testThatModelsCanBeLoaded() throws IOException, URISyntaxException {
         Settings settings = Settings.builder()
-                .put("ingest.opennlp.model.file.names", "en-ner-persons.bin")
-                .put("ingest.opennlp.model.file.locations", "en-ner-locations.bin")
-                .put("ingest.opennlp.model.file.dates", "en-ner-dates.bin")
+                .put("ingest.opennlp.model.file.ner.names", "en-ner-persons.bin")
+                .put("ingest.opennlp.model.file.ner.locations", "en-ner-locations.bin")
+                .put("ingest.opennlp.model.file.ner.dates", "en-ner-dates.bin")
+                .put("ingest.opennlp.model.file.pos", "en-pos-maxent.bin")
                 .build();
         OpenNlpService service = new OpenNlpService(getDataPath("/models/en-ner-persons.bin").getParent(), settings);
         service.start();
@@ -54,5 +58,10 @@ public class OpenNlpServiceTests extends ESTestCase {
         Set<String> dates = service.find("Yesterday has been the hottest day of the year.", "dates");
         assertThat(dates, hasSize(1));
         assertThat(dates, contains("Yesterday"));
+
+        Map<String, Number> stats = service.countTags("Kobe Bryant was one of the best basketball players of all time.", null, false);
+        assertThat(stats.keySet(), hasSize(9));
+        assertThat(stats, hasKey("NN"));
+        assertThat(stats.get("NN").intValue(), comparesEqualTo(2));
     }
 }

--- a/src/test/resources/rest-api-spec/test/ingest_opennlp/10_basic.yaml
+++ b/src/test/resources/rest-api-spec/test/ingest_opennlp/10_basic.yaml
@@ -7,5 +7,6 @@
     - do:
         nodes.info: {}
 
-    - match:  { nodes.$master.plugins.0.name: ingest-opennlp }
-    - match:  { nodes.$master.ingest.processors.0.type: opennlp }
+    - match:  { nodes.$master.ingest.processors.0.type: opennlp_ner }
+    - match:  { nodes.$master.ingest.processors.1.type: opennlp_pos }
+

--- a/src/test/resources/rest-api-spec/test/ingest_opennlp/20_opennlp_ner_processor.yaml
+++ b/src/test/resources/rest-api-spec/test/ingest_opennlp/20_opennlp_ner_processor.yaml
@@ -1,5 +1,5 @@
 ---
-"Test opennlp processor with defaults":
+"Test opennlp named entity extraction processor with defaults":
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"
@@ -8,7 +8,7 @@
             "description": "_description",
             "processors": [
               {
-                "opennlp" : {
+                "opennlp_ner" : {
                   "field" : "field1"
                 }
               }
@@ -45,7 +45,7 @@
             "description": "_description",
             "processors": [
               {
-                "opennlp" : {
+                "opennlp_ner" : {
                   "field" : "field1",
                   "fields": [ "locations" ]
                 }

--- a/src/test/resources/rest-api-spec/test/ingest_opennlp/30_opennlp_pos_processor.yaml
+++ b/src/test/resources/rest-api-spec/test/ingest_opennlp/30_opennlp_pos_processor.yaml
@@ -1,0 +1,85 @@
+---
+"Test opennlp part of speech tagging processor with defaults":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "opennlp_pos" : {
+                  "field" : "field1"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year."}
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.field1: "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year." }
+  - length: { _source.tags: 14 }
+  - match: { _source.tags.CC: 1 }
+  - match: { _source.tags.CD: 3 }
+  - match: { _source.tags.DT: 5 }
+  - match: { _source.tags.IN: 4 }
+  - match: { _source.tags.JJ: 1 }
+  - match: { _source.tags.JJS: 2 }
+  - match: { _source.tags.NN: 6 }
+  - match: { _source.tags.NNP: 7 }
+  - match: { _source.tags.NNS: 3 }
+  - match: { _source.tags.PUNCT: 5 }
+  - match: { _source.tags.RB: 6 }
+  - match: { _source.tags.VBD: 1 }
+  - match: { _source.tags.VBN: 2 }
+  - match: { _source.tags.VBZ: 4 }
+
+---
+"Test limiting certain tags works":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "opennlp_pos" : {
+                  "field" : "field1",
+                  "tags": [ "NN", "VBZ" ]
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        type: test
+        id: 1
+        pipeline: "my_pipeline"
+        body: {field1: "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year."}
+
+  - do:
+      get:
+        index: test
+        type: test
+        id: 1
+  - match: { _source.field1: "Kobe Bryant was one of the best basketball players of all times. Not even Michael Jordan has ever scored 81 points in one game. Munich is really an awesome city, but New York is as well. Yesterday has been the hottest day of the year." }
+  - length: { _source.tags: 2 }
+  - match: { _source.tags.NN: 6 }
+  - match: { _source.tags.VBZ: 4 }
+


### PR DESCRIPTION
Hi Alexander. Please have a look on the following pull request. 

It contains:
- A new processor that uses OpenNLP POS tagger to count the different part of speech tags (the named entity recognition processor was renamed to avoid confusion between the two processors of the plugin)
- Upgrade to Elasticsearch 5.6.1
- Compatibility with Gradle 4.x
- Updated tests and README.md